### PR TITLE
Fix collect_metrics and update_resources for cgroup v2

### DIFF
--- a/crates/shim/src/cgroup.rs
+++ b/crates/shim/src/cgroup.rs
@@ -164,13 +164,13 @@ fn set_cpu_usage(cpu_usage: &mut CPUUsage, stat: &String) {
 
         match parts[0] {
             "usage_usec" => {
-                cpu_usage.set_total(parts[1].parse().unwrap());
+                cpu_usage.set_total(parts[1].parse().unwrap_or_default());
             }
             "user_usec" => {
-                cpu_usage.set_user(parts[1].parse().unwrap());
+                cpu_usage.set_user(parts[1].parse().unwrap_or_default());
             }
             "system_usec" => {
-                cpu_usage.set_kernel(parts[1].parse().unwrap());
+                cpu_usage.set_kernel(parts[1].parse().unwrap_or_default());
             }
             _ => {}
         }


### PR DESCRIPTION
## Cgroup v2
In function `collect_metrics ` and `update_resources `, the cgroup is loaded by calling
```rust
Cgroup::load_with_relative_paths(hierarchies::auto(), Path::new("."), path)
```
But it doesnt work in Cgroup v2. So I changed it to use
```rust
Cgroup::load(hierarchies::auto(), Path::new(v.trim_start_matches('/')))
```
instead in v2 case and it works.


## the cgroup CpuAcct and CPU subsystem
The cgroup CpuAcct subsystem is used for perfect CPU stats collecting, but it doesn't exist on some OS distributions. So in that case, we should collect CPU metrics by using CPU subsystem instead, just like the way runc shim does.


