### PR TITLE
fix(shim): optimize monitor to avoid intermittent hangs

### DIFF
--- a/crates/runc-shim/src/asynchronous/runc.rs
+++ b/crates/runc-shim/src/asynchronous/runc.rs
@@ -16,10 +16,7 @@
 
 use std::{
     convert::TryFrom,
-    os::{
-        fd::AsRawFd,
-        unix::prelude::ExitStatusExt,
-    },
+    os::{fd::AsRawFd, unix::prelude::ExitStatusExt},
     path::{Path, PathBuf},
     process::ExitStatus,
     sync::Arc,
@@ -431,7 +428,8 @@ async fn copy_console(
 ) -> Result<Console> {
     debug!("copy_console: waiting for runtime to send console fd");
     let stream = console_socket.accept().await?;
-    let f = asyncify(move || -> Result<std::fs::File> { receive_socket(stream.as_raw_fd()) }).await?;
+    let f =
+        asyncify(move || -> Result<std::fs::File> { receive_socket(stream.as_raw_fd()) }).await?;
     let f = File::from_std(f);
     if !stdio.stdin.is_empty() {
         debug!("copy_console: pipe stdin to console");
@@ -621,7 +619,12 @@ async fn copy_io_or_console<P>(
 
 #[async_trait]
 impl Spawner for ShimExecutor {
-    async fn execute(&self, cmd: Command, after_start: Box<dyn Fn()+Send>, wait_output: bool) -> runc::Result<(ExitStatus, u32, String, String)> {
+    async fn execute(
+        &self,
+        cmd: Command,
+        after_start: Box<dyn Fn() + Send>,
+        wait_output: bool,
+    ) -> runc::Result<(ExitStatus, u32, String, String)> {
         let mut cmd = cmd;
         let subscription = monitor_subscribe(Topic::Pid)
             .await
@@ -636,15 +639,20 @@ impl Spawner for ShimExecutor {
         };
         after_start();
         let pid = child.id().unwrap();
-        let (stdout, stderr, exit_code) = if wait_output {
+        let (stdout, stderr, exit_result) = if wait_output {
             tokio::join!(
-            read_std(child.stdout),
-            read_std(child.stderr),
-            wait_pid(pid as i32, subscription)
-        )
-        }  else  {
-            ("".to_string(), "".to_string(), wait_pid(pid as i32, subscription).await)
+                read_std(child.stdout),
+                read_std(child.stderr),
+                wait_pid(pid as i32, subscription)
+            )
+        } else {
+            (
+                "".to_string(),
+                "".to_string(),
+                wait_pid(pid as i32, subscription).await,
+            )
         };
+        let exit_code = exit_result.map_err(|e| runc::error::Error::Other(Box::new(e)))?;
         let status = ExitStatus::from_raw(exit_code);
         monitor_unsubscribe(sid).await.unwrap_or_default();
         Ok((status, pid, stdout, stderr))
@@ -667,17 +675,25 @@ where
     "".to_string()
 }
 
-async fn wait_pid(pid: i32, s: Subscription) -> i32 {
+async fn wait_pid(pid: i32, s: Subscription) -> containerd_shim::Result<i32> {
     let mut s = s;
     loop {
-        if let Some(ExitEvent {
-            subject: Subject::Pid(epid),
-            exit_code: code,
-        }) = s.rx.recv().await
-        {
-            if pid == epid {
-                monitor_unsubscribe(s.id).await.unwrap_or_default();
-                return code;
+        match s.rx.recv().await {
+            Some(ExitEvent {
+                subject: Subject::Pid(epid),
+                exit_code: code,
+            }) => {
+                if pid == epid {
+                    monitor_unsubscribe(s.id).await.unwrap_or_default();
+                    return Ok(code);
+                }
+            }
+            Some(_) => continue,
+            None => {
+                return Err(containerd_shim::Error::Other(format!(
+                    "monitor disconnected while waiting for {}",
+                    pid
+                )))
             }
         }
     }

--- a/crates/runc-shim/src/synchronous/runc.rs
+++ b/crates/runc-shim/src/synchronous/runc.rs
@@ -658,7 +658,7 @@ impl Spawner for ShimExecutor {
         let (stdout, stderr, exit_code) = (
             read_std(child.stdout),
             read_std(child.stderr),
-            wait_pid(pid as i32, subscription),
+            wait_pid(pid as i32, subscription).map_err(|e| runc::error::Error::Other(Box::new(e)))?,
         );
         let status = ExitStatus::from_raw(exit_code);
         Ok((status, pid, stdout, stderr))

--- a/crates/shim/src/asynchronous/monitor.rs
+++ b/crates/shim/src/asynchronous/monitor.rs
@@ -14,17 +14,14 @@
    limitations under the License.
 */
 
-use std::collections::HashMap;
+use std::{collections::HashMap, sync::Mutex};
 
 use lazy_static::lazy_static;
 use log::error;
-use tokio::sync::{
-    mpsc::{channel, Receiver, Sender},
-    Mutex,
-};
+use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender};
 
 use crate::{
-    error::{Error, Result},
+    error::Result,
     monitor::{ExitEvent, Subject, Topic},
 };
 
@@ -40,29 +37,38 @@ lazy_static! {
 }
 
 pub async fn monitor_subscribe(topic: Topic) -> Result<Subscription> {
-    let mut monitor = MONITOR.lock().await;
+    let mut monitor = MONITOR.lock().unwrap();
     let s = monitor.subscribe(topic)?;
     Ok(s)
 }
 
 pub async fn monitor_unsubscribe(sub_id: i64) -> Result<()> {
-    let mut monitor = MONITOR.lock().await;
+    let mut monitor = MONITOR.lock().unwrap();
     monitor.unsubscribe(sub_id)
 }
 
 pub async fn monitor_notify_by_pid(pid: i32, exit_code: i32) -> Result<()> {
-    let monitor = MONITOR.lock().await;
-    monitor.notify_by_pid(pid, exit_code).await
+    let mut monitor = MONITOR.lock().unwrap();
+    let subject = Subject::Pid(pid);
+    monitor.notify_topic(&Topic::Pid, &subject, exit_code);
+    monitor.notify_topic(&Topic::All, &subject, exit_code);
+    Ok(())
 }
 
 pub fn monitor_notify_by_pid_blocking(pid: i32, exit_code: i32) -> Result<()> {
-    let monitor = MONITOR.blocking_lock();
-    monitor.notify_by_pid_blocking(pid, exit_code)
+    let mut monitor = MONITOR.lock().unwrap();
+    let subject = Subject::Pid(pid);
+    monitor.notify_topic(&Topic::Pid, &subject, exit_code);
+    monitor.notify_topic(&Topic::All, &subject, exit_code);
+    Ok(())
 }
 
 pub async fn monitor_notify_by_exec(id: &str, exec_id: &str, exit_code: i32) -> Result<()> {
-    let monitor = MONITOR.lock().await;
-    monitor.notify_by_exec(id, exec_id, exit_code).await
+    let mut monitor = MONITOR.lock().unwrap();
+    let subject = Subject::Exec(id.into(), exec_id.into());
+    monitor.notify_topic(&Topic::Exec, &subject, exit_code);
+    monitor.notify_topic(&Topic::All, &subject, exit_code);
+    Ok(())
 }
 
 pub struct Monitor {
@@ -73,17 +79,28 @@ pub struct Monitor {
 
 pub(crate) struct Subscriber {
     pub(crate) topic: Topic,
-    pub(crate) tx: Sender<ExitEvent>,
+    pub(crate) tx: UnboundedSender<ExitEvent>,
 }
 
 pub struct Subscription {
     pub id: i64,
-    pub rx: Receiver<ExitEvent>,
+    pub rx: UnboundedReceiver<ExitEvent>,
+}
+
+impl Drop for Subscription {
+    fn drop(&mut self) {
+        let id = self.id;
+        // std::sync::Mutex::lock is safe in any context (sync/async).
+        // It will only block the thread for a very short time.
+        if let Ok(mut monitor) = MONITOR.lock() {
+            let _ = monitor.unsubscribe(id);
+        }
+    }
 }
 
 impl Monitor {
     pub fn subscribe(&mut self, topic: Topic) -> Result<Subscription> {
-        let (tx, rx) = channel::<ExitEvent>(128);
+        let (tx, rx) = unbounded_channel::<ExitEvent>();
         let id = self.seq_id;
         self.seq_id += 1;
         let subscriber = Subscriber {
@@ -99,68 +116,23 @@ impl Monitor {
         Ok(Subscription { id, rx })
     }
 
-    pub async fn notify_by_pid(&self, pid: i32, exit_code: i32) -> Result<()> {
-        let subject = Subject::Pid(pid);
-        self.notify_topic(&Topic::Pid, &subject, exit_code).await;
-        self.notify_topic(&Topic::All, &subject, exit_code).await;
-        Ok(())
-    }
-
-    pub fn notify_by_pid_blocking(&self, pid: i32, exit_code: i32) -> Result<()> {
-        let subject = Subject::Pid(pid);
-        self.notify_topic_blocking(&Topic::Pid, &subject, exit_code);
-        self.notify_topic_blocking(&Topic::All, &subject, exit_code);
-        Ok(())
-    }
-
-    pub async fn notify_by_exec(&self, cid: &str, exec_id: &str, exit_code: i32) -> Result<()> {
-        let subject = Subject::Exec(cid.into(), exec_id.into());
-        self.notify_topic(&Topic::Exec, &subject, exit_code).await;
-        self.notify_topic(&Topic::All, &subject, exit_code).await;
-        Ok(())
-    }
-
-    // notify_topic try best to notify exit codes to all subscribers and log errors.
-    async fn notify_topic(&self, topic: &Topic, subject: &Subject, exit_code: i32) {
-        let mut results = Vec::new();
+    fn notify_topic(&mut self, topic: &Topic, subject: &Subject, exit_code: i32) {
+        let mut dead_subscribers = Vec::new();
         if let Some(subs) = self.topic_subs.get(topic) {
-            let subscribers = subs.iter().filter_map(|x| self.subscribers.get(x));
-            for sub in subscribers {
-                let res = sub
-                    .tx
-                    .send(ExitEvent {
+            for i in subs {
+                if let Some(sub) = self.subscribers.get(i) {
+                    if let Err(e) = sub.tx.send(ExitEvent {
                         subject: subject.clone(),
                         exit_code,
-                    })
-                    .await
-                    .map_err(other_error!(e, "failed to send exit code"));
-                results.push(res);
+                    }) {
+                        error!("failed to send exit code to subscriber {}: {:?}", i, e);
+                        dead_subscribers.push(*i);
+                    }
+                }
             }
         }
-        let mut result_iter = results.iter();
-        while let Some(Err(e)) = result_iter.next() {
-            error!("failed to send exit code to subscriber {:?}", e)
-        }
-    }
-
-    fn notify_topic_blocking(&self, topic: &Topic, subject: &Subject, exit_code: i32) {
-        let mut results = Vec::new();
-        if let Some(subs) = self.topic_subs.get(topic) {
-            let subscribers = subs.iter().filter_map(|x| self.subscribers.get(x));
-            for sub in subscribers {
-                let res = sub
-                    .tx
-                    .blocking_send(ExitEvent {
-                        subject: subject.clone(),
-                        exit_code,
-                    })
-                    .map_err(other_error!(e, "failed to send exit code"));
-                results.push(res);
-            }
-        }
-        let mut result_iter = results.iter();
-        while let Some(Err(e)) = result_iter.next() {
-            error!("failed to send exit code to subscriber {:?}", e)
+        for id in dead_subscribers {
+            let _ = self.unsubscribe(id);
         }
     }
 
@@ -179,71 +151,235 @@ impl Monitor {
 
 #[cfg(test)]
 mod tests {
+    use std::time::Duration;
+
+    use lazy_static::lazy_static;
+    use tokio::sync::Mutex;
+
     use crate::{
         asynchronous::monitor::{
             monitor_notify_by_exec, monitor_notify_by_pid, monitor_subscribe, monitor_unsubscribe,
+            MONITOR,
         },
-        monitor::{ExitEvent, Subject, Topic},
+        monitor::{Subject, Topic},
     };
 
+    lazy_static! {
+        // Use tokio::sync::Mutex for tests to avoid holding std::sync::MutexGuard across awaits
+        static ref TEST_LOCK: Mutex<()> = Mutex::new(());
+    }
+
     #[tokio::test]
-    async fn test_monitor() {
+    async fn test_monitor_table() {
+        let _guard = TEST_LOCK.lock().await;
+        // Clean up any leftovers from previous tests
+        {
+            let mut monitor = MONITOR.lock().unwrap();
+            monitor.subscribers.clear();
+            monitor.topic_subs.clear();
+        }
+
+        struct TestCase {
+            name: &'static str,
+            subscribe_to: Topic,
+            notify_pid: Option<i32>,
+            notify_exec: Option<(&'static str, &'static str)>,
+            expected_pid: Option<i32>,
+            expected_exec: Option<(&'static str, &'static str)>,
+        }
+
+        let cases = vec![
+            TestCase {
+                name: "pid_topic_receives_pid_event",
+                subscribe_to: Topic::Pid,
+                notify_pid: Some(101),
+                notify_exec: None,
+                expected_pid: Some(101),
+                expected_exec: None,
+            },
+            TestCase {
+                name: "pid_topic_ignores_exec_event",
+                subscribe_to: Topic::Pid,
+                notify_pid: None,
+                notify_exec: Some(("c1", "e1")),
+                expected_pid: None,
+                expected_exec: None,
+            },
+            TestCase {
+                name: "exec_topic_receives_exec_event",
+                subscribe_to: Topic::Exec,
+                notify_pid: None,
+                notify_exec: Some(("c2", "e2")),
+                expected_pid: None,
+                expected_exec: Some(("c2", "e2")),
+            },
+            TestCase {
+                name: "all_topic_receives_both",
+                subscribe_to: Topic::All,
+                notify_pid: Some(102),
+                notify_exec: Some(("c3", "e3")),
+                expected_pid: Some(102),
+                expected_exec: Some(("c3", "e3")),
+            },
+        ];
+
+        for tc in cases {
+            let mut s = monitor_subscribe(tc.subscribe_to.clone()).await.unwrap();
+
+            if let Some(pid) = tc.notify_pid {
+                monitor_notify_by_pid(pid, 0).await.unwrap();
+            }
+            if let Some((cid, eid)) = tc.notify_exec {
+                monitor_notify_by_exec(cid, eid, 0).await.unwrap();
+            }
+
+            if let Some(exp_pid) = tc.expected_pid {
+                let event = tokio::time::timeout(Duration::from_millis(200), s.rx.recv())
+                    .await
+                    .unwrap_or_else(|_| panic!("{}: timed out waiting for pid", tc.name))
+                    .expect("channel closed");
+                match event.subject {
+                    Subject::Pid(p) => assert_eq!(p, exp_pid, "{}", tc.name),
+                    _ => panic!("{}: expected pid, got {:?}", tc.name, event.subject),
+                }
+            }
+
+            if let Some((exp_cid, exp_eid)) = tc.expected_exec {
+                let event = tokio::time::timeout(Duration::from_millis(200), s.rx.recv())
+                    .await
+                    .unwrap_or_else(|_| panic!("{}: timed out waiting for exec", tc.name))
+                    .expect("channel closed");
+                match event.subject {
+                    Subject::Exec(c, e) => {
+                        assert_eq!(c, exp_cid, "{}", tc.name);
+                        assert_eq!(e, exp_eid, "{}", tc.name);
+                    }
+                    _ => panic!("{}: expected exec, got {:?}", tc.name, event.subject),
+                }
+            }
+
+            // Ensure no extra messages
+            let res = tokio::time::timeout(Duration::from_millis(50), s.rx.recv()).await;
+            assert!(res.is_err(), "{}: received unexpected extra event", tc.name);
+
+            monitor_unsubscribe(s.id).await.unwrap();
+        }
+    }
+
+    #[tokio::test]
+    async fn test_monitor_backpressure() {
+        let _guard = TEST_LOCK.lock().await;
+        // Clean up
+        {
+            let mut monitor = MONITOR.lock().unwrap();
+            monitor.subscribers.clear();
+            monitor.topic_subs.clear();
+        }
+
         let mut s = monitor_subscribe(Topic::Pid).await.unwrap();
-        let mut s1 = monitor_subscribe(Topic::All).await.unwrap();
-        let mut s2 = monitor_subscribe(Topic::Exec).await.unwrap();
-        monitor_notify_by_pid(13, 128).await.unwrap();
-        monitor_notify_by_exec("test-container", "test-exec", 139)
+        let sid = s.id;
+        let count = 200;
+        let base_pid = 10000;
+
+        let receiver = tokio::spawn(async move {
+            let mut received = 0;
+            while received < count {
+                if let Some(event) = s.rx.recv().await {
+                    match event.subject {
+                        Subject::Pid(pid) => {
+                            assert_eq!(pid, base_pid + received);
+                        }
+                        _ => continue,
+                    }
+                    received += 1;
+                    if received % 10 == 0 {
+                        tokio::time::sleep(Duration::from_millis(1)).await;
+                    }
+                } else {
+                    break;
+                }
+            }
+            received
+        });
+
+        for i in 0..count {
+            monitor_notify_by_pid(base_pid + i, 0).await.unwrap();
+        }
+
+        let received_count = tokio::time::timeout(Duration::from_secs(5), receiver)
             .await
-            .unwrap();
-        // pid subscription receive only pid event
-        if let Some(ExitEvent {
-            subject: Subject::Pid(p),
-            exit_code: ec,
-        }) = s.rx.recv().await
+            .expect("Test timed out")
+            .expect("Receiver task failed");
+
+        assert_eq!(received_count, count);
+        monitor_unsubscribe(sid).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_monitor_reliability() {
+        let _guard = TEST_LOCK.lock().await;
+        // Clean up
         {
-            assert_eq!(ec, 128);
-            assert_eq!(p, 13);
-        } else {
-            panic!("can not receive the notified event");
+            let mut monitor = MONITOR.lock().unwrap();
+            monitor.subscribers.clear();
+            monitor.topic_subs.clear();
         }
 
-        // topic all receive all events
-        if let Some(ExitEvent {
-            subject: Subject::Pid(p),
-            exit_code: ec,
-        }) = s1.rx.recv().await
-        {
-            assert_eq!(ec, 128);
-            assert_eq!(p, 13);
-        } else {
-            panic!("can not receive the notified event");
-        }
-        if let Some(ExitEvent {
-            subject: Subject::Exec(cid, eid),
-            exit_code: ec,
-        }) = s1.rx.recv().await
-        {
-            assert_eq!(cid, "test-container");
-            assert_eq!(eid, "test-exec");
-            assert_eq!(ec, 139);
-        } else {
-            panic!("can not receive the notified event");
+        enum Action {
+            Unsubscribe,
+            Drop,
         }
 
-        // exec topic only receive exec exit event
-        if let Some(ExitEvent {
-            subject: Subject::Exec(cid, eid),
-            exit_code: ec,
-        }) = s2.rx.recv().await
-        {
-            assert_eq!(cid, "test-container");
-            assert_eq!(eid, "test-exec");
-            assert_eq!(ec, 139);
-        } else {
-            panic!("can not receive the notified event");
+        struct ReliabilityCase {
+            name: &'static str,
+            action: Action,
         }
-        monitor_unsubscribe(s.id).await.unwrap();
-        monitor_unsubscribe(s1.id).await.unwrap();
-        monitor_unsubscribe(s2.id).await.unwrap();
+
+        let cases = vec![
+            ReliabilityCase {
+                name: "explicit_unsubscribe",
+                action: Action::Unsubscribe,
+            },
+            ReliabilityCase {
+                name: "drop_handle",
+                action: Action::Drop,
+            },
+        ];
+
+        for tc in cases {
+            let s_to_remove = monitor_subscribe(Topic::Pid).await.unwrap();
+            let mut s_stay = monitor_subscribe(Topic::Pid).await.unwrap();
+            let rid = s_to_remove.id;
+            let test_pid = 20000;
+
+            match tc.action {
+                Action::Unsubscribe => {
+                    monitor_unsubscribe(rid).await.unwrap();
+                }
+                Action::Drop => {
+                    drop(s_to_remove);
+                    tokio::time::sleep(Duration::from_millis(100)).await;
+                }
+            }
+
+            monitor_notify_by_pid(test_pid, 0).await.unwrap();
+
+            // s_stay should receive the event
+            let event = tokio::time::timeout(Duration::from_millis(500), s_stay.rx.recv())
+                .await
+                .unwrap_or_else(|_| panic!("{}: stay subscription timed out", tc.name))
+                .expect("channel closed");
+
+            match event.subject {
+                Subject::Pid(p) => assert_eq!(p, test_pid, "{}", tc.name),
+                _ => panic!("{}: unexpected event", tc.name),
+            }
+
+            {
+                let monitor = MONITOR.lock().unwrap();
+                assert!(!monitor.subscribers.contains_key(&rid), "{}", tc.name);
+            }
+            monitor_unsubscribe(s_stay.id).await.unwrap();
+        }
     }
 }

--- a/crates/shim/src/mount.rs
+++ b/crates/shim/src/mount.rs
@@ -466,7 +466,7 @@ pub fn mount_rootfs(
     let s = monitor_subscribe(Topic::All)?;
     match unsafe { fork() } {
         Ok(ForkResult::Parent { child, .. }) => {
-            let code: MountExitCode = wait_pid(i32::from(child), s).into();
+            let code: MountExitCode = wait_pid(i32::from(child), s)?.into();
             code.into()
         }
         Ok(ForkResult::Child) => {

--- a/crates/shim/src/synchronous/monitor.rs
+++ b/crates/shim/src/synchronous/monitor.rs
@@ -20,6 +20,7 @@ use std::{
         mpsc::{channel, Receiver, Sender},
         Mutex,
     },
+    time::Duration,
 };
 
 use lazy_static::lazy_static;
@@ -48,13 +49,24 @@ pub fn monitor_subscribe(topic: Topic) -> Result<Subscription> {
 }
 
 pub fn monitor_notify_by_pid(pid: i32, exit_code: i32) -> Result<()> {
-    let monitor = MONITOR.lock().unwrap();
-    monitor.notify_by_pid(pid, exit_code)
+    let mut monitor = MONITOR.lock().unwrap();
+    let subject = Subject::Pid(pid);
+    monitor.notify_topic(&Topic::Pid, &subject, exit_code);
+    monitor.notify_topic(&Topic::All, &subject, exit_code);
+    Ok(())
 }
 
 pub fn monitor_notify_by_exec(id: &str, exec_id: &str, exit_code: i32) -> Result<()> {
-    let monitor = MONITOR.lock().unwrap();
-    monitor.notify_by_exec(id, exec_id, exit_code)
+    let mut monitor = MONITOR.lock().unwrap();
+    let subject = Subject::Exec(id.into(), exec_id.into());
+    monitor.notify_topic(&Topic::Exec, &subject, exit_code);
+    monitor.notify_topic(&Topic::All, &subject, exit_code);
+    Ok(())
+}
+
+pub fn monitor_unsubscribe(id: i64) -> Result<()> {
+    let mut monitor = MONITOR.lock().unwrap();
+    monitor.unsubscribe(id)
 }
 
 pub struct Monitor {
@@ -90,34 +102,26 @@ impl Monitor {
         Ok(Subscription { id, rx })
     }
 
-    pub fn notify_by_pid(&self, pid: i32, exit_code: i32) -> Result<()> {
-        let subject = Subject::Pid(pid);
-        self.notify_topic(&Topic::Pid, &subject, exit_code);
-        self.notify_topic(&Topic::All, &subject, exit_code);
-        Ok(())
-    }
-
-    pub fn notify_by_exec(&self, cid: &str, exec_id: &str, exit_code: i32) -> Result<()> {
-        let subject = Subject::Exec(cid.into(), exec_id.into());
-        self.notify_topic(&Topic::Exec, &subject, exit_code);
-        self.notify_topic(&Topic::All, &subject, exit_code);
-        Ok(())
-    }
-
-    fn notify_topic(&self, topic: &Topic, subject: &Subject, exit_code: i32) {
-        self.topic_subs.get(topic).map_or((), |subs| {
+    fn notify_topic(&mut self, topic: &Topic, subject: &Subject, exit_code: i32) {
+        let mut dead_subscribers = Vec::new();
+        if let Some(subs) = self.topic_subs.get(topic) {
             for i in subs {
-                self.subscribers.get(i).and_then(|sub| {
-                    sub.tx
-                        .send(ExitEvent {
-                            subject: subject.clone(),
-                            exit_code,
-                        })
-                        .map_err(|e| warn!("failed to send {}", e))
-                        .ok()
-                });
+                if let Some(sub) = self.subscribers.get(i) {
+                    // channel::Sender::send is non-blocking when using unbounded channel.
+                    // Sending while holding the lock prevents races with unsubscribe.
+                    if let Err(e) = sub.tx.send(ExitEvent {
+                        subject: subject.clone(),
+                        exit_code,
+                    }) {
+                        warn!("failed to send exit event to subscriber {}: {}", i, e);
+                        dead_subscribers.push(*i);
+                    }
+                }
             }
-        })
+        }
+        for id in dead_subscribers {
+            let _ = self.unsubscribe(id);
+        }
     }
 
     pub fn unsubscribe(&mut self, id: i64) -> Result<()> {
@@ -142,16 +146,186 @@ impl Drop for Subscription {
     }
 }
 
-pub fn wait_pid(pid: i32, s: Subscription) -> i32 {
+pub fn wait_pid(pid: i32, s: Subscription) -> Result<i32> {
     loop {
-        if let Ok(ExitEvent {
-            subject: Subject::Pid(epid),
-            exit_code: code,
-        }) = s.rx.recv()
-        {
-            if pid == epid {
-                return code;
+        match s.rx.recv_timeout(Duration::from_secs(1)) {
+            Ok(ExitEvent {
+                subject: Subject::Pid(epid),
+                exit_code: code,
+            }) => {
+                if pid == epid {
+                    return Ok(code);
+                }
+            }
+            Ok(_) => continue,
+            Err(std::sync::mpsc::RecvTimeoutError::Timeout) => continue,
+            Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
+                return Err(crate::Error::Other(format!(
+                    "monitor disconnected while waiting for {}",
+                    pid
+                )));
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::thread;
+
+    use super::*;
+
+    lazy_static! {
+        static ref SYNC_TEST_LOCK: Mutex<()> = Mutex::new(());
+    }
+
+    #[test]
+    fn test_monitor_table_sync() {
+        let _guard = SYNC_TEST_LOCK.lock().unwrap();
+        {
+            let mut monitor = MONITOR.lock().unwrap();
+            monitor.subscribers.clear();
+            monitor.topic_subs.clear();
+        }
+
+        struct TestCase {
+            name: &'static str,
+            subscribe_to: Topic,
+            notify_pid: Option<i32>,
+            notify_exec: Option<(&'static str, &'static str)>,
+            expected_pid: Option<i32>,
+            expected_exec: Option<(&'static str, &'static str)>,
+        }
+
+        let cases = vec![
+            TestCase {
+                name: "pid_topic_receives_pid_event",
+                subscribe_to: Topic::Pid,
+                notify_pid: Some(301),
+                notify_exec: None,
+                expected_pid: Some(301),
+                expected_exec: None,
+            },
+            TestCase {
+                name: "exec_topic_receives_exec_event",
+                subscribe_to: Topic::Exec,
+                notify_pid: None,
+                notify_exec: Some(("c2", "e2")),
+                expected_pid: None,
+                expected_exec: Some(("c2", "e2")),
+            },
+        ];
+
+        for tc in cases {
+            let s = monitor_subscribe(tc.subscribe_to.clone()).unwrap();
+
+            if let Some(pid) = tc.notify_pid {
+                monitor_notify_by_pid(pid, 0).unwrap();
+            }
+            if let Some((cid, eid)) = tc.notify_exec {
+                monitor_notify_by_exec(cid, eid, 0).unwrap();
+            }
+
+            if let Some(exp_pid) = tc.expected_pid {
+                let event =
+                    s.rx.recv_timeout(Duration::from_millis(100))
+                        .unwrap_or_else(|_| panic!("{}: timed out", tc.name));
+                match event.subject {
+                    Subject::Pid(p) => assert_eq!(p, exp_pid, "{}", tc.name),
+                    _ => panic!("{}: unexpected subject", tc.name),
+                }
+            }
+
+            if let Some((exp_cid, exp_eid)) = tc.expected_exec {
+                let event =
+                    s.rx.recv_timeout(Duration::from_millis(100))
+                        .unwrap_or_else(|_| panic!("{}: timed out", tc.name));
+                match event.subject {
+                    Subject::Exec(c, e) => {
+                        assert_eq!(c, exp_cid, "{}", tc.name);
+                        assert_eq!(e, exp_eid, "{}", tc.name);
+                    }
+                    _ => panic!("{}: unexpected subject", tc.name),
+                }
+            }
+
+            monitor_unsubscribe(s.id).unwrap();
+        }
+    }
+
+    #[test]
+    fn test_monitor_backpressure_sync() {
+        let _guard = SYNC_TEST_LOCK.lock().unwrap();
+        {
+            let mut monitor = MONITOR.lock().unwrap();
+            monitor.subscribers.clear();
+            monitor.topic_subs.clear();
+        }
+
+        let s = monitor_subscribe(Topic::Pid).unwrap();
+        let sid = s.id;
+        let count = 200;
+        let base_pid = 20000;
+
+        let handle = thread::spawn(move || {
+            let mut received = 0;
+            while received < count {
+                if let Ok(event) = s.rx.recv_timeout(Duration::from_secs(5)) {
+                    match event.subject {
+                        Subject::Pid(pid) => {
+                            assert_eq!(pid, base_pid + received)
+                        }
+                        _ => continue,
+                    }
+                    received += 1;
+                    if received % 10 == 0 {
+                        thread::sleep(Duration::from_millis(1));
+                    }
+                } else {
+                    break;
+                }
+            }
+            received
+        });
+
+        for i in 0..count {
+            monitor_notify_by_pid(base_pid + i, 0).unwrap();
+        }
+
+        let received_count = handle.join().expect("Receiver thread panicked");
+        assert_eq!(received_count, count);
+
+        monitor_unsubscribe(sid).unwrap();
+    }
+
+    #[test]
+    fn test_monitor_reliability_sync() {
+        let _guard = SYNC_TEST_LOCK.lock().unwrap();
+        {
+            let mut monitor = MONITOR.lock().unwrap();
+            monitor.subscribers.clear();
+            monitor.topic_subs.clear();
+        }
+
+        let s_to_drop = monitor_subscribe(Topic::Pid).unwrap();
+        let s_stay = monitor_subscribe(Topic::Pid).unwrap();
+        let rid = s_to_drop.id;
+        let test_pid = 30000;
+
+        drop(s_to_drop);
+        thread::sleep(Duration::from_millis(50));
+
+        monitor_notify_by_pid(test_pid, 0).unwrap();
+
+        let event = s_stay.rx.recv_timeout(Duration::from_millis(200)).unwrap();
+        match event.subject {
+            Subject::Pid(p) => assert_eq!(p, test_pid),
+            _ => panic!("unexpected event"),
+        }
+
+        let monitor = MONITOR.lock().unwrap();
+        assert!(!monitor.subscribers.contains_key(&rid));
+        drop(monitor);
+        monitor_unsubscribe(s_stay.id).unwrap();
     }
 }


### PR DESCRIPTION
 ### Description

  This PR addresses intermittent hangs and potential deadlocks in the containerd-shim monitor module by optimizing the locking mechanism and event distribution logic.


### The Problem
  The previous implementation suffered from two main issues:
   1. Async Lock in Destructors: The global MONITOR used tokio::sync::Mutex. When a Subscription was dropped, it attempted to acquire this lock to unsubscribe. If the drop occurred outside an active Tokio
      runtime (e.g., during shim shutdown or from a blocking thread), it caused panics or hung the process.
   2. Reaper Thread Blocking: Using bounded channels for exit events meant that the "Reaper" thread (responsible for SIGCHLD and waitpid) could block if a subscriber was slow to consume events. This prevented
      other process exits from being collected, leading to zombie processes and a total shim hang under heavy workloads.


### The Solution
   1. Synchronous Locking: Replaced tokio::sync::Mutex with std::sync::Mutex for the global MONITOR singleton. This ensures that Subscription::drop can safely and synchronously unregister itself in any
      execution context without relying on the async runtime.
   2. Unbounded Channels: Switched to unbounded channels (tokio::sync::mpsc::unbounded_channel for async and std::sync::mpsc::channel for sync). Since PID exit events are critical and must not be lost,
      unbounded channels ensure that the producer (the Reaper thread) is never blocked by subscriber backpressure.
   3. Strict FIFO Ordering: By using unbounded channels, the send operation is now a non-blocking memory operation. This allowed moving the notification logic back inside the lock, ensuring strict FIFO
      ordering of events and providing a guarantee that no events are delivered after a successful unsubscription.